### PR TITLE
fix whitespace and spelling errors for linting

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,10 @@ Help:
         -v, --verbose                    Verbose output
         -t, --tries=#                    Set max retries: Default 10
         -s, --sleep=secs                 Constant sleep amount (seconds)
-        -m, --min=secs                   Exponenetial Backoff: minimum sleep amount (seconds): Default 0.3
-        -x, --max=secs                   Exponenetial Backoff: maximum sleep amount (seconds): Default 60
+        -m, --min=secs                   Exponential Backoff: minimum sleep amount (seconds): Default 0.3
+        -x, --max=secs                   Exponential Backoff: maximum sleep amount (seconds): Default 60
         -f, --fail="script +cmds"        Fail Script: run in case of final failure
-    
+
 ### Examples
 
 No problem:

--- a/retry
+++ b/retry
@@ -4,7 +4,7 @@ GETOPT_BIN=$IN_GETOPT_BIN
 GETOPT_BIN=${GETOPT_BIN:-getopt}
 
 __sleep_amount() {
-  if [ -n "$constant_sleep" ]; then 
+  if [ -n "$constant_sleep" ]; then
     sleep_time=$constant_sleep
   else
     #TODO: check for awk
@@ -17,7 +17,7 @@ __log_out() {
   echo "$1" 1>&2
 }
 
-# Paramters: max_tries min_sleep max_sleep constant_sleep fail_script EXECUTION_COMMAND
+# Parameters: max_tries min_sleep max_sleep constant_sleep fail_script EXECUTION_COMMAND
 retry()
 {
   local max_tries="$1"; shift
@@ -83,8 +83,8 @@ Usage: $retry [options] -- execute command
     -v, --verbose                    Verbose output
     -t, --tries=#                    Set max retries: Default 10
     -s, --sleep=secs                 Constant sleep amount (seconds)
-    -m, --min=secs                   Exponenetial Backoff: minimum sleep amount (seconds): Default 0.3
-    -x, --max=secs                   Exponenetial Backoff: maximum sleep amount (seconds): Default 60
+    -m, --min=secs                   Exponential Backoff: minimum sleep amount (seconds): Default 0.3
+    -x, --max=secs                   Exponential Backoff: maximum sleep amount (seconds): Default 60
     -f, --fail="script +cmds"        Fail Script: run in case of final failure
 EOF
   }
@@ -159,5 +159,5 @@ EOF
   done
 
   retry "$max_tries" "$min_sleep" "$max_sleep" "$constant_sleep" "$fail_script" "$@"
-  
+
 fi


### PR DESCRIPTION
bitcoin's retry version isn't under subtree version control.
I am trying to get them in sync. 

https://github.com/bitcoin/bitcoin/tree/master/ci/retry