### PR TITLE
Fix ShellCheck warnings and add tests

### DIFF
--- a/retry
+++ b/retry
@@ -4,11 +4,12 @@ GETOPT_BIN=$IN_GETOPT_BIN
 GETOPT_BIN=${GETOPT_BIN:-getopt}
 
 __sleep_amount() {
-  if [ -n "$constant_sleep" ]; then 
+  if [ -n "$constant_sleep" ]; then
     sleep_time=$constant_sleep
   else
     #TODO: check if user would rather use one of the other possible dependencies: python, ruby, bc, dc
-    sleep_time=`awk "BEGIN {t = $min_sleep * $(( (1<<($attempts -1)) )); print (t > $max_sleep ? $max_sleep : t)}"`
+    # shellcheck disable=SC2004
+    sleep_time=$(awk "BEGIN {t = $min_sleep * $(( (1<<($attempts -1)) )); print (t > $max_sleep ? $max_sleep : t)}")
   fi
 }
 
@@ -37,10 +38,10 @@ retry()
 
 
   while [[ $return_code -ne 0 && $attempts -le $max_tries ]]; do
-    if [ $attempts -gt 0 ]; then
+    if [[ $attempts -gt 0 ]]; then
       __sleep_amount
       __log_out "Before retry #$attempts: sleeping $sleep_time seconds"
-      sleep $sleep_time
+      sleep "$sleep_time"
     fi
 
     P="$1"
@@ -54,14 +55,14 @@ retry()
       # command not found
       exit $return_code
     elif [ $return_code -ne 0 ]; then
-      attempts=$[$attempts +1]
+      attempts=$((attempts +1))
     fi
   done
 
-  if [ $attempts -gt $max_tries ]; then
+  if [[ $attempts -gt $max_tries ]]; then
     if [ -n "$fail_script" ]; then
       __log_out "Retries exhausted, running fail script"
-      eval $fail_script
+      eval "$fail_script"
     else
       __log_out "Retries exhausted"
     fi
@@ -71,11 +72,13 @@ retry()
 }
 
 # If we're being sourced, don't worry about such things
-if [ "$BASH_SOURCE" == "$0" ]; then
+if [ "${BASH_SOURCE[0]}" == "$0" ]; then
   # Prints the help text
   help()
   {
-    local retry=$(basename $0)
+    local retry
+    retry=$(basename "$0")
+
     cat <<EOF
 Usage: $retry [options] -- execute command
     -h, -?, --help
@@ -108,10 +111,9 @@ EOF
   OPTIONS=vt:s:m:x:f:
   LONGOPTIONS=verbose,tries:,sleep:,min:,max:,fail:
 
-  PARSED=$($GETOPT_BIN --options="$OPTIONS" --longoptions="$LONGOPTIONS" --name "$0" -- "$@")
-  if [[ $? -ne 0 ]]; then
-    # e.g. $? == 1
-    #  then getopt has complained about wrong arguments to stdout
+  if ! PARSED=$($GETOPT_BIN --options="$OPTIONS" --longoptions="$LONGOPTIONS" --name "$0" -- "$@"); then
+    # if exit status is 1,
+    # then getopt has complained about wrong arguments to stdout
     exit 2
   fi
   # read getopt’s output this way to handle the quoting right:

--- a/tests
+++ b/tests
@@ -1,0 +1,24 @@
+#! /usr/bin/env bash
+
+failed=
+
+./retry 'echo hello' \
+| grep -q hello \
+|| failed=' 1-command-runs'
+
+./retry -t 3 false 2>&1 \
+| tr '\n' ! \
+| grep -q 'Before retry #3: sleeping [0-9.]* seconds!Retries exhausted!$' \
+|| failed="$failed 2-retrying-works"
+
+output=$(./retry -t 1 -f 'echo "mission failed"; exit 99' false 2>&1)
+status=$?
+
+echo "$output!$status" \
+| tr '\n' ! \
+| grep -q 'mission failed!99!$' \
+|| failed="$failed 3-fail-script-runs"
+
+[[ $failed = "" ]] && exit 0
+echo "tests failed:$failed"
+exit 1


### PR DESCRIPTION
Running [ShellCheck](https://github.com/koalaman/shellcheck) on `retry` generates the following list of warnings. This PR fixes the warnings. It also adds `tests`, a Bash script that runs three basic functionality tests on `retry`.

```

In retry line 11:
    sleep_time=`awk "BEGIN {t = $min_sleep * $(( (1<<($attempts -1)) )); print (t > $max_sleep ? $max_sleep : t)}"`
               ^-- SC2006 (style): Use $(...) notation instead of legacy backticks `...`.
                                                      ^-------^ SC2004 (style): $/${} is unnecessary on arithmetic variables.

Did you mean: 
    sleep_time=$(awk "BEGIN {t = $min_sleep * $(( (1<<($attempts -1)) )); print (t > $max_sleep ? $max_sleep : t)}")


In retry line 43:
      sleep $sleep_time
            ^---------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
      sleep "$sleep_time"


In retry line 57:
      attempts=$[$attempts +1]
               ^-------------^ SC2007 (style): Use $((..)) instead of deprecated $[..]


In retry line 61:
  if [ $attempts -gt $max_tries ]; then
       ^-------^ SC2086 (info): Double quote to prevent globbing and word splitting.
                     ^--------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
  if [ "$attempts" -gt "$max_tries" ]; then


In retry line 64:
      eval $fail_script
           ^----------^ SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
      eval "$fail_script"


In retry line 74:
if [ "$BASH_SOURCE" == "$0" ]; then
      ^----------^ SC2128 (warning): Expanding an array without an index only gives the first element.


In retry line 78:
    local retry=$(basename $0)
          ^---^ SC2155 (warning): Declare and assign separately to avoid masking return values.
                           ^-- SC2086 (info): Double quote to prevent globbing and word splitting.

Did you mean: 
    local retry=$(basename "$0")


In retry line 112:
  if [[ $? -ne 0 ]]; then
        ^-- SC2181 (style): Check exit code directly with e.g. 'if ! mycmd;', not indirectly with $?.

For more information:
  https://www.shellcheck.net/wiki/SC2128 -- Expanding an array without an ind...
  https://www.shellcheck.net/wiki/SC2155 -- Declare and assign separately to ...
  https://www.shellcheck.net/wiki/SC2086 -- Double quote to prevent globbing ...
```